### PR TITLE
Add dotenv configuration for Firestore

### DIFF
--- a/user-auth-service/config/firestore.js
+++ b/user-auth-service/config/firestore.js
@@ -1,6 +1,8 @@
 const { Firestore } = require("@google-cloud/firestore");
 const path = require("path");
 
+require("dotenv").config();
+
 const pathKey = path.resolve("./vizia-sa.json");
 
 const dbFirestore = new Firestore({


### PR DESCRIPTION
This pull request includes a small but important change to the `user-auth-service` configuration file for Firestore. The change ensures that environment variables are properly loaded.

* [`user-auth-service/config/firestore.js`](diffhunk://#diff-c3f2d6a7cce97a9e6c138d19014d01f87fd04df9d01fab0628503585bac2a950R4-R5): Added `dotenv` configuration to load environment variables.